### PR TITLE
added nogit flag

### DIFF
--- a/io-package.json
+++ b/io-package.json
@@ -343,6 +343,7 @@
             "es": "Este adaptador permite importar proyectos KNX desde ETS y comunicarse con dispositivos a través de KNX IP Gateway",
             "pl": "Ten adapter umożliwia import projektów KNX z ETS i komunikację z urządzeniami za pośrednictwem bramy KNX IP"
         },
+        "nogit": true,
         "materialize": true,
         "license": "CC-BY-NC-4.0",
         "platform": "Javascript/Node.js",


### PR DESCRIPTION
often people try to install this adapter from GitHub, which of course not works correctly as no executable code lies there. With `nogit` flag we can tell admin, that GH installs are not supported for this adapter.