### PR TITLE
Update license related data and fix package version

### DIFF
--- a/io-package.json
+++ b/io-package.json
@@ -187,7 +187,6 @@
     },
     "nogit": true,
     "materialize": true,
-    "license": "CC-BY-NC-4.0",
     "platform": "Javascript/Node.js",
     "mode": "daemon",
     "icon": "knx.png",

--- a/io-package.json
+++ b/io-package.json
@@ -300,7 +300,7 @@
     "licenseInformation": {
       "link": "https://github.com/ioBroker/ioBroker.knx?tab=readme-ov-file#license-requirements",
       "type": "limited",
-      "license": "CC BY-NC 4.0"
+      "license": "CC-BY-NC-4.0"
     }
   },
   "native": {

--- a/package.json
+++ b/package.json
@@ -16,12 +16,6 @@
     }
   ],
   "homepage": "https://github.com/ioBroker/ioBroker.knx",
-  "licenses": [
-    {
-      "type": "CC-BY-NC-4.0",
-      "url": "https://github.com/ioBroker/ioBroker.knx/blob/master/LICENSE"
-    }
-  ],
   "license": "CC-BY-NC-4.0",
   "keywords": [
     "ioBroker",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iobroker.knx",
-  "version": "2.0.26",
+  "version": "2.0.27",
   "description": "ioBroker knx Adapter ",
   "author": {
     "name": "K.Ringmann",


### PR DESCRIPTION
- removed "licenses" from package.json as this field is outdated
- removed "license" from io-package.json as this field is invalid if licenseInformation is present
- fixed license text at io-package.json
- updated version number at package.json (was lower than version at npm)

Please review and merge this PR.
A new version is not required, at repository builder will pick the information directly from github repo anyway.