### PR TITLE
Remove 'Versions' section from changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,8 +272,6 @@ relation.
 
 ## Changelog
 
-## Versions
-
 ### 2.0.40 (05.04.2026)
 
 * fixed connection state response handling


### PR DESCRIPTION
Removed the 'Versions' section from the changelog.

##versions prohibits looking for releases. They must be located directly within section ##changelog